### PR TITLE
Item14827: Unescaped left brace in regex

### DIFF
--- a/lib/Foswiki/Plugins/ChartPlugin/Table.pm
+++ b/lib/Foswiki/Plugins/ChartPlugin/Table.pm
@@ -169,7 +169,7 @@ sub _parseOutTables {
 
         if ( !($insidePRE) ) {
 
-            if (/%TABLE{.*name="(.*?)".*}%/) {
+            if (/%TABLE\{.*name="(.*?)".*}%/) {
                 $tableName = $1;
             }
             if (/^\s*\|.*\|\s*$/) {


### PR DESCRIPTION
Not sure if it is what Item14827 is referencing as that is latex related. But this plugin is referenced too.